### PR TITLE
Add turbojpeg dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ RUN apk add --no-cache \
       expat-dev \
       gettext-dev \
       gperf \
-      libtool \
+      libjpeg-turbo-dev \
       libpng-dev \
+      libtool \
       py-lxml \
       py-six \
       python3 \

--- a/wscript
+++ b/wscript
@@ -58,7 +58,7 @@ def configure(ctx):
         ctx.check_cfg(package='poppler', uselib_store='poppler',
                       args=['--cflags', '--libs', '--static'])
 
-        poppler_stlib = "fontconfig expat freetype lcms2 openjp2 png bz2 z pthread"
+        poppler_stlib = "fontconfig expat freetype lcms2 openjp2 jpeg png bz2 z pthread"
         for lib in poppler_stlib.split():
             ctx.check_cxx(stlib=lib, uselib_store='poppler')
 


### PR DESCRIPTION
Somehow this was missed before. The effect is for poppler to warn during
configuring that this library is missing and that bad things might happen.