### PR TITLE
Zero initialize Options

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,6 +225,8 @@ public:
 	std::string filename;
 	int start, end;
 
+	Options() : filename(""), start(0), end(0) {}
+
 	bool range_specified() const {
 		return start != 0 && end != 0;
 	}


### PR DESCRIPTION
Previously it was uninitialized. Now I give it a default constructor and do it explicitly.

We didn't spot this before because the compilation environment happened to have it zero initialized, but not the environment in which we make our production executables...