### PR TITLE
Use C++11 memory management

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -398,7 +398,7 @@ int main(int argc, char *argv[]) {
 		install_syscall_filter();
 	}
 
-	auto file = std::unique_ptr<BaseStream>(open_file(options.filename));
+	auto file = open_file(options.filename);
 
 	if (!globalParams) {
 		globalParams = new GlobalParams("/usr/share/poppler");
@@ -410,7 +410,7 @@ int main(int argc, char *argv[]) {
 	}
 
 
-	std::unique_ptr<PDFDoc> doc(new PDFDoc(file.get()));
+	std::unique_ptr<PDFDoc> doc(new PDFDoc(file));
 	if (!doc) {
 		std::cerr << "Problem loading document." << std::endl;
 		exit(64);

--- a/wscript
+++ b/wscript
@@ -37,14 +37,14 @@ def options(opt):
 def configure(ctx):
     ctx.load('compiler_cxx')
 
-    ctx.check(features='cxx cxxprogram', cxxflags="--std=c++11")
+    ctx.check(features='cxx cxxprogram', cxxflags="--std=c++14")
 
     ctx.env.append_value("CXXFLAGS", [
         "-g",
         "-Wall",
         "-Werror",
         "-ansi",
-        "--std=c++11",
+        "--std=c++14",
     ])
 
     if ctx.options.release:


### PR DESCRIPTION
Automatically delete things when they go out of scope using `unique_ptr`
rather than explicitly deleting.

# Needs rebase against #15 