### PR TITLE
Add --bitmap, make page into a map rather than array

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+.git
 Dockerfile

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -273,8 +273,11 @@ void dump_page_paths(Page *page) {
 }
 
 void dump_page(Page *page) {
-	int n = 2;
+	int n = 3;
 	packer.pack_map(n);
+
+	packer.pack("Size");
+	packer.pack(std::make_tuple(page->getMediaWidth(), page->getMediaHeight()));
 
 	packer.pack("Glyphs");
 	dump_page_glyphs(page);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,9 @@ static int install_syscall_filter(void) {
 		/* Grab the system call number. */
 		EXAMINE_SYSCALL,
 		/* List allowed syscalls. */
+		ALLOW_SYSCALL(access),
+		ALLOW_SYSCALL(fstatfs),
+		ALLOW_SYSCALL(readlink),
 		ALLOW_SYSCALL(open),
 		ALLOW_SYSCALL(close),
 		ALLOW_SYSCALL(ioctl),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -458,7 +458,7 @@ std::string parse_options(int argc, char *argv[], Options *options) {
 }
 
 void usage() {
-	std::cerr << "usage: pdf2msgpack [--meta-only] [--pages=a-b] <filename>" << std::endl;
+	std::cerr << "usage: pdf2msgpack [--bitmap] [--meta-only] [--pages=a-b] <filename>" << std::endl;
 }
 
 int main(int argc, char *argv[]) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -448,11 +448,11 @@ int main(int argc, char *argv[]) {
 		options.start = 1;
 		options.end = doc->getNumPages();
 	} else if (options.start > doc->getNumPages() ||
-			   options.end > doc->getNumPages()) {
+				 options.end > doc->getNumPages()) {
 		std::cerr << "Error: specified page range"
-				  << " (" << options.start << " - " << options.end << ")"
-				  << " exceeds document length"
-				  << " (" << doc->getNumPages() << ")" << std::endl;
+							<< " (" << options.start << " - " << options.end << ")"
+							<< " exceeds document length"
+							<< " (" << doc->getNumPages() << ")" << std::endl;
 		usage();
 		exit(1);
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -273,8 +273,13 @@ void dump_page_paths(Page *page) {
 }
 
 void dump_page(Page *page) {
-	packer.pack_array(2);
+	int n = 2;
+	packer.pack_map(n);
+
+	packer.pack("Glyphs");
 	dump_page_glyphs(page);
+
+	packer.pack("Paths");
 	dump_page_paths(page);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -511,7 +511,7 @@ int main(int argc, char *argv[]) {
 
 	// This version number should be incremented whenever the output format
 	// is changed in a way which will break existing parsers.
-	const int output_format_version = 0;
+	const int output_format_version = 1;
 	packer.pack(output_format_version);
 
 	dump_document_meta(doc.get(), uMap);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -385,7 +385,7 @@ std::string parse_options(int argc, char *argv[], Options *options) {
 }
 
 void usage() {
-	std::cerr << "usage: pdf2msgpack [--pages=a-b] <filename>" << std::endl;
+	std::cerr << "usage: pdf2msgpack [--meta-only] [--pages=a-b] <filename>" << std::endl;
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
**BUMPS OUTPUT VERSION**.

Now Pages are represented with a map with the following keys:

`{"Size": (w, h), "Glyphs": [], "Paths": []}` and optionally
`{"Bitmap": bytes}`.

The bitmap is only rendered if `--bitmap` is supplied.