### PR TITLE
Add --font-info (default off)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,23 @@ static int install_syscall_filter(void) {
   return 0;
 }
 
+class Options {
+public:
+  std::string filename;
+  int start, end;
+  bool meta_only;
+  bool bitmap;
+
+  Options() : filename(""), start(0), end(0), meta_only(false), bitmap(false) {}
+
+  bool range_specified() const { return start != 0 && end != 0; }
+
+  int page_count() const {
+    // Note: range is inclusive on the right.
+    return end - start + 1;
+  }
+};
+
 static std::string fmt(Object *o, UnicodeMap *uMap) {
   if (!o)
     return "<nil>";
@@ -341,23 +358,6 @@ void dump_page_bitmap(Page *page) {
     data += bitmap->getRowSize();
   }
 }
-
-class Options {
-public:
-  std::string filename;
-  int start, end;
-  bool meta_only;
-  bool bitmap;
-
-  Options() : filename(""), start(0), end(0), meta_only(false), bitmap(false) {}
-
-  bool range_specified() const { return start != 0 && end != 0; }
-
-  int page_count() const {
-    // Note: range is inclusive on the right.
-    return end - start + 1;
-  }
-};
 
 void dump_page(Page *page, const Options &options) {
   int n = 3;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -483,7 +483,7 @@ std::string parse_options(int argc, char *argv[], Options *options) {
 }
 
 void usage() {
-  std::cerr << "usage: pdf2msgpack [--font-info] [--bitmap] [--meta-only] "
+  std::cerr << "usage: pdf2msgpack [--bitmap] [--font-info] [--meta-only] "
                "[--pages=a-b] <filename>"
             << std::endl;
 }


### PR DESCRIPTION
It turns out font-info can be very slow since it inspects the objects of
every page. This can delay time-to-first-byte quite a bit (many seconds).

Therefore, this PR makes it optional and default to off.