### PR TITLE
Fix conditional syscall-reporter

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,11 +4,13 @@
 #include <sstream>
 
 #include <libgen.h>
-#include <linux/seccomp.h>
 #include <stdio.h>
-#include <sys/prctl.h>
-
 #include <sys/stat.h>
+
+#ifndef DISABLE_SYSCALL_FILTER
+#include <linux/seccomp.h>
+#include <sys/prctl.h>
+#endif
 
 #include <poppler/DateInfo.h>
 #include <poppler/FontInfo.h>
@@ -34,17 +36,17 @@
 
 msgpack::packer<std::ostream> packer(&std::cout);
 
-#include "seccomp-bpf.h"
 #ifdef ENABLE_SYSCALL_REPORTER
+#include "seccomp-bpf.h"
 #include "syscall-reporter.h"
 #endif
 
 static int install_syscall_filter(void) {
-#ifdef DISABLE_SYSCALL_REPORTER
+#ifdef DISABLE_SYSCALL_FILTER
   if (true) {
     return 0;
   }
-#endif
+#else
   struct sock_filter filter[] = {
       /* Validate architecture. */
       VALIDATE_ARCHITECTURE,
@@ -81,6 +83,7 @@ static int install_syscall_filter(void) {
     exit(99);
   }
   return 0;
+#endif // else branch of #ifdef DISABLE_SYSCALL_FILTER
 }
 
 static std::string fmt(Object *o, UnicodeMap *uMap) {

--- a/wscript
+++ b/wscript
@@ -42,6 +42,7 @@ def configure(ctx):
     ctx.env.append_value("CXXFLAGS", [
         "-g",
         "-Wall",
+        "-Wno-unused-private-field",
         "-Werror",
         "-ansi",
         "--std=c++14",
@@ -90,8 +91,9 @@ def configure(ctx):
         ctx.msg("Enable syscall reporter (***NOT FOR PRODUCTION***)", "yes",
                 color="RED")
 
-    if ctx.options.disable_syscall_filter:
-        ctx.env.append_value("CXXFLAGS", ["-DDISABLE_SYSCALL_REPORTER"])
+    ctx.env.DISABLE_SYSCALL_FILTER = ctx.options.disable_syscall_filter
+    if ctx.env.DISABLE_SYSCALL_FILTER:
+        ctx.env.append_value("CXXFLAGS", ["-DDISABLE_SYSCALL_FILTER"])
         ctx.msg("Disable syscall filter (***NOT FOR PRODUCTION***)", "yes",
                 color="RED")
 
@@ -103,8 +105,8 @@ def build(ctx):
         features = 'static_linking'
 
     sources = ctx.path.ant_glob('src/main.cpp')
-    if not ctx.options.disable_syscall_filter:
-        sources += ctx.path.ant_glob('src/syscall-reporter.c')
+    if not ctx.env.DISABLE_SYSCALL_FILTER:
+        sources += ctx.path.ant_glob('src/syscall-reporter.cpp')
 
     ctx.program(
         source=sources,


### PR DESCRIPTION
I had mistyped the syscall-reporter.cpp filename and it was being
silently not included.

Also, we had a dependency on a header which was absent.

Closes #21.