### PR TITLE
Fix poppler include paths

### DIFF
--- a/src/DumpAsTextDev.h
+++ b/src/DumpAsTextDev.h
@@ -1,6 +1,7 @@
-#include <poppler/GfxFont.h>
-#include <poppler/GfxState.h>
-#include <poppler/OutputDev.h>
+// /usr/include/poppler/...
+#include <GfxFont.h>
+#include <GfxState.h>
+#include <OutputDev.h>
 
 #include "util.hpp"
 

--- a/src/DumpPathsAsMsgPackDev.h
+++ b/src/DumpPathsAsMsgPackDev.h
@@ -3,9 +3,11 @@
 #include <string>
 
 #include <msgpack.hpp>
-#include <poppler/GfxFont.h>
-#include <poppler/GfxState.h>
-#include <poppler/OutputDev.h>
+
+// /usr/include/poppler/...
+#include <GfxFont.h>
+#include <GfxState.h>
+#include <OutputDev.h>
 
 #include "util.hpp"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,20 +12,21 @@
 #include <sys/prctl.h>
 #endif
 
-#include <poppler/DateInfo.h>
-#include <poppler/FontInfo.h>
-#include <poppler/Gfx.h>
-#include <poppler/GlobalParams.h>
-#include <poppler/PDFDoc.h>
-#include <poppler/Page.h>
-#include <poppler/SplashOutputDev.h>
-#include <poppler/TextOutputDev.h>
-#include <poppler/UTF.h>
-#include <poppler/UnicodeMap.h>
-#include <poppler/goo/GooList.h>
-#include <poppler/goo/GooString.h>
-#include <poppler/goo/gfile.h>
-#include <poppler/splash/SplashBitmap.h>
+// /usr/include/poppler/...
+#include <DateInfo.h>
+#include <FontInfo.h>
+#include <Gfx.h>
+#include <GlobalParams.h>
+#include <PDFDoc.h>
+#include <Page.h>
+#include <SplashOutputDev.h>
+#include <TextOutputDev.h>
+#include <UTF.h>
+#include <UnicodeMap.h>
+#include <goo/GooList.h>
+#include <goo/GooString.h>
+#include <goo/gfile.h>
+#include <splash/SplashBitmap.h>
 
 #include <msgpack.hpp>
 

--- a/wscript
+++ b/wscript
@@ -82,7 +82,8 @@ def configure(ctx):
         ctx.check_cfg(package='poppler', uselib_store='poppler',
                       args=['--cflags', '--libs'])
 
-    ctx.check_cxx(header_name="poppler/PDFDoc.h", use="poppler",
+    # /usr/include/poppler/...
+    ctx.check_cxx(header_name="PDFDoc.h", use="poppler",
                   msg="Checking libpoppler-private-dev (poppler configured " +
                       "with --enable-xpdf-headers)")
 


### PR DESCRIPTION
Previously we included `poppler/` erroneously.