### PR TITLE
Add Homebrew formula for easy install on macOS

### DIFF
--- a/pdf2msgpack.rb
+++ b/pdf2msgpack.rb
@@ -1,0 +1,22 @@
+class Pdf2msgpack < Formula
+  desc "Efficiently export PDF content in an easily machine readable format"
+  homepage "https://github.com/scraperwiki/pdf2msgpack"
+  head "https://github.com/scraperwiki/pdf2msgpack.git"
+  url "https://github.com/scraperwiki/pdf2msgpack/archive/v0.2.tar.gz"
+  sha256 "302416b7bcd73eb0f3d66cd019525e10e2ebc53341dd0bee6edb91850ff61a5e"
+
+  depends_on "pkg-config" => :build
+  depends_on "python3"    => :build  # WAF
+  depends_on "poppler"  # libpoppler-private-dev (`--enable-xpdf-headers`)
+
+  def install
+    system "./waf", "configure", "--prefix=#{prefix}",
+                                 "--disable-syscall-filter",
+                                 "--release"
+    system "./waf", "install"
+  end
+
+  test do
+    system "true"
+  end
+end


### PR DESCRIPTION
This should cover all build and runtime dependencies.

To install, run: `brew install https://raw.github.com/scraperwiki/pdf2msgpack/master/pdf2msgpack.rb`.

Some notes:

- Since all formula require to run a test, it would be good if we could have access to a fake mini-pdf to convert or at least a `--version` option to we know it runs.
- We should make a new version (e.g. 0.3) with the latest changes to allow pushing this to the main repo ("tap": _homebrew-core_) so users can just `brew install pdf2msgpack`.