### PR TITLE
Add line style information

### DIFF
--- a/src/DumpPathsAsMsgPackDev.h
+++ b/src/DumpPathsAsMsgPackDev.h
@@ -14,6 +14,9 @@
 const int EO_FILL = 10;
 const int STROKE = 11;
 const int FILL = 12;
+const int SET_STROKE_COLOR = 13;
+const int SET_STROKE_WIDTH = 14;
+const int SET_FILL_COLOR = 15;
 
 typedef struct { double x, y; } Point;
 
@@ -50,6 +53,36 @@ public:
   }
 };
 
+bool operator!=(const GfxRGB &a, const GfxRGB &b) {
+  return !(a.r == b.r && a.g == b.g && a.b == b.b);
+}
+
+
+namespace msgpack {
+MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
+namespace adaptor {
+
+template <>
+struct pack<GfxRGB> {
+  template <typename Stream>
+  msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& p, GfxRGB const &color) const {
+    auto c = [](const GfxColorComp x) -> uint8_t {
+      // 255 * x + 0.5  =  256 * x - x + 0x8000
+      return static_cast<uint8_t>(((x << 8) - x + 0x8000) >> 16);
+    };
+    p.pack_array(3);
+    p.pack_fix_uint8(c(color.r));
+    p.pack_fix_uint8(c(color.g));
+    p.pack_fix_uint8(c(color.b));
+    return p;
+  }
+};
+
+} // namespace adaptor
+} // MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
+} // namespace msgpack
+
+
 class DumpPathsAsMsgPackDev : public OutputDev {
 public:
   DumpPathsAsMsgPackDev() : packer(buffer), path_count(0) {}
@@ -57,6 +90,9 @@ public:
   std::ostringstream buffer;
   msgpack::packer<std::ostream> packer;
   int path_count;
+
+  GfxRGB prevFillRGB = {0, 0, 0}, prevStrokeRGB = {0, 0, 0};
+  double prevStrokeWidth;
 
 public:
   // Writes the packed path information to a stream.
@@ -75,28 +111,75 @@ public:
   GBool interpretType3Chars() { return gTrue; }
 
   void eoFill(GfxState *state) {
-    doPath(state->getCTM(), state->getPath(), EO_FILL);
+    doPath(state, state->getCTM(), state->getPath(), EO_FILL);
   }
 
   void stroke(GfxState *state) {
-    doPath(state->getCTM(), state->getPath(), STROKE);
+    doPath(state, state->getCTM(), state->getPath(), STROKE);
   }
 
   void fill(GfxState *state) {
-    doPath(state->getCTM(), state->getPath(), FILL);
+    doPath(state, state->getCTM(), state->getPath(), FILL);
   }
 
-  void doPath(const Mat2x3 &transform, GfxPath *path, int path_type) {
+  void recordStateChanges(GfxState *state, int path_type) {
+    switch (path_type) {
+
+      case FILL:
+      case EO_FILL:
+        GfxRGB curFillRGB;
+        state->getFillRGB(&curFillRGB);
+        if (prevFillRGB != curFillRGB) {
+          prevFillRGB = curFillRGB;
+          packer.pack_array(2);
+          packer.pack_fix_uint8(SET_FILL_COLOR);
+          packer.pack(curFillRGB);
+          path_count++;
+        }
+
+        // break;
+        // Fallthrough. Strokes apply to fills, too.
+
+      case STROKE:
+        GfxRGB curStrokeRGB;
+        state->getStrokeRGB(&curStrokeRGB);
+        if (prevStrokeRGB != curStrokeRGB) {
+          prevStrokeRGB = curStrokeRGB;
+          packer.pack_array(2);
+          packer.pack_fix_uint8(SET_STROKE_COLOR);
+          packer.pack(curStrokeRGB);
+          path_count++;
+        }
+
+        double curStrokeWidth;
+        curStrokeWidth = state->getLineWidth();
+        if (prevStrokeWidth != curStrokeWidth) {
+          prevStrokeWidth = curStrokeWidth;
+          packer.pack(std::make_tuple(SET_STROKE_WIDTH, curStrokeWidth));
+          path_count++;
+        }
+
+        break;
+
+      default:
+        std::cerr << "unknown path type: " << path_type << std::endl;
+
+    }
+  }
+
+  void doPath(GfxState *state, const Mat2x3 &transform, GfxPath *path, int path_type) {
+    recordStateChanges(state, path_type);
+
     auto n = path->getNumSubpaths();
 
     for (auto i = 0; i < n; ++i) {
       auto subpath = path->getSubpath(i);
       auto m = subpath->getNumPoints();
       auto j = 0;
+
       std::vector<PathPoint> path_points;
       while (j < m) {
         if (subpath->getCurve(j)) {
-
           auto a = transform.mul(subpath->getX(j + 0), subpath->getY(j + 0)),
                b = transform.mul(subpath->getX(j + 1), subpath->getY(j + 1)),
                c = transform.mul(subpath->getX(j + 2), subpath->getY(j + 2));
@@ -110,6 +193,7 @@ public:
         }
         ++j;
       }
+
       if (!path_points.empty()) {
         if (subpath->isClosed()) {
           path_points.push_back(path_points[0]);

--- a/src/DumpPathsAsMsgPackDev.h
+++ b/src/DumpPathsAsMsgPackDev.h
@@ -85,11 +85,13 @@ struct pack<GfxRGB> {
 
 class DumpPathsAsMsgPackDev : public OutputDev {
 public:
-  DumpPathsAsMsgPackDev() : packer(buffer), path_count(0) {}
+  DumpPathsAsMsgPackDev() : packer(buffer), item_count(0) {}
 
   std::ostringstream buffer;
   msgpack::packer<std::ostream> packer;
-  int path_count;
+
+  // Number of items written to the stream.
+  int item_count;
 
   GfxRGB prevFillRGB = {0, 0, 0}, prevStrokeRGB = {0, 0, 0};
   double prevStrokeWidth;
@@ -102,7 +104,7 @@ public:
   // The path information is written to the `packer` and
   // the packed data is in this method streamed to `out`.
   void pack(std::ostream &out) {
-    msgpack::packer<std::ostream>(out).pack_array(path_count);
+    msgpack::packer<std::ostream>(out).pack_array(item_count);
     out << buffer.str();
   }
 
@@ -134,7 +136,7 @@ public:
           packer.pack_array(2);
           packer.pack_fix_uint8(SET_FILL_COLOR);
           packer.pack(curFillRGB);
-          path_count++;
+          item_count++;
         }
 
         // break;
@@ -148,7 +150,7 @@ public:
           packer.pack_array(2);
           packer.pack_fix_uint8(SET_STROKE_COLOR);
           packer.pack(curStrokeRGB);
-          path_count++;
+          item_count++;
         }
 
         double curStrokeWidth;
@@ -156,7 +158,7 @@ public:
         if (prevStrokeWidth != curStrokeWidth) {
           prevStrokeWidth = curStrokeWidth;
           packer.pack(std::make_tuple(SET_STROKE_WIDTH, curStrokeWidth));
-          path_count++;
+          item_count++;
         }
 
         break;
@@ -199,7 +201,7 @@ public:
           path_points.push_back(path_points[0]);
         }
         packer.pack(std::make_tuple(path_type, path_points));
-        path_count++;
+        item_count++;
       }
     }
   }

--- a/src/DumpPathsAsMsgPackDev.h
+++ b/src/DumpPathsAsMsgPackDev.h
@@ -94,7 +94,7 @@ public:
   int item_count;
 
   GfxRGB prevFillRGB = {0, 0, 0}, prevStrokeRGB = {0, 0, 0};
-  double prevStrokeWidth;
+  double prevStrokeWidth = -1;
 
 public:
   // Writes the packed path information to a stream.


### PR DESCRIPTION
* Stroke (color, width)
* Fill (stroke, fill color)

Information is encoded onto the stream by writing elements into the path
list with SET_FILL_COLOR, SET_STROKE_COLOR and SET_STROKE_WIDTH.

## Notes:

* Style information is only written when it changes, rather than for every object.
* Colour starts off black.
* Line width is always given in the stream when we first encounter a line.
* Should be backwards compatible, because readers will just drop elements they don't understand.

## Example test output:

Remember: 

```c
const int EO_FILL = 10;
const int STROKE = 11;
const int FILL = 12;
const int SET_STROKE_COLOR = 13;
const int SET_STROKE_WIDTH = 14;
const int SET_FILL_COLOR = 15;
```

```
[1,
 {b'Creator': b'cairo 1.13.1 (http://cairographics.org)',
  b'FileName': b'test_paths.pdf',
  b'FontInfo': None,
  b'Pages': 1,
  b'Producer': b'cairo 1.13.1 (http://cairographics.org)'},
 {b'Glyphs': [[[97.142859, 62.47945800000005, 117.430859, 99.69545800000004], b'S'],
              [[117.430859, 62.47945800000005, 136.982859, 99.69545800000004], b'o'],
              [[136.982859, 62.47945800000005, 168.150859, 99.69545800000004], b'm'],
              [[168.150859, 62.47945800000005, 187.830859, 99.69545800000004], b'e'],
              [[187.830859, 62.47945800000005, 197.974859, 99.69545800000004], b' '],
              [[197.974859, 62.47945800000005, 217.110859, 99.69545800000004], b'e'],
              [[217.110859, 62.47945800000005, 236.022859, 99.69545800000004], b'x'],
              [[236.022859, 62.47945800000005, 255.60685900000001, 99.69545800000004], b'a'],
              [[255.60685900000001, 62.47945800000005, 286.774859, 99.69545800000004], b'm'],
              [[286.774859, 62.47945800000005, 307.062859, 99.69545800000004], b'p'],
              [[307.062859, 62.47945800000005, 315.926859, 99.69545800000004], b'l'],
              [[315.926859, 62.47945800000005, 335.606859, 99.69545800000004], b'e'],
              [[335.606859, 62.47945800000005, 345.750859, 99.69545800000004], b' '],
              [[345.750859, 62.47945800000005, 358.294859, 99.69545800000004], b't'],
              [[358.294859, 62.47945800000005, 377.974859, 99.69545800000004], b'e'],
              [[377.974859, 62.47945800000005, 394.61485899999997, 99.69545800000004], b's'],
              [[394.61485899999997, 62.47945800000005, 407.15885899999995, 99.69545800000004], b't'],
              [[407.15885899999995, 62.47945800000005, 417.39885899999996, 99.69545800000004], b' '],
              [[417.39885899999996, 62.47945800000005, 437.68685899999997, 99.69545800000004], b'p'],
              [[437.68685899999997, 62.47945800000005, 457.270859, 99.69545800000004], b'a'],
              [[457.270859, 62.47945800000005, 469.81485899999996, 99.69545800000004], b't'],
              [[469.81485899999996, 62.47945800000005, 490.0708589999999, 99.69545800000004], b'h'],
              [[490.0708589999999, 62.47945800000005, 506.7108589999999, 99.69545800000004], b's']],
  b'Paths': [[14, 1.0],
             [12,
              [[91.43, 147.0307710000002],
               [283.43, 147.0307710000002],
               [283.43, 297.8897710000002],
               [91.43, 297.8897710000002],
               [91.43, 147.0307710000002],
               [91.43, 147.0307710000002]]],
             [15, [255, 0, 0]],
             [12,
              [[362.039, 165.49177100000009],
               [492.953, 165.49177100000009],
               [492.953, 281.85877100000005],
               [362.039, 281.85877100000005],
               [362.039, 165.49177100000009],
               [362.039, 165.49177100000009]]],
             [15, [0, 255, 0]],
             [13, [0, 255, 0]],
             [14, 0.8],
             [12, [[54.145, 443.484], [158.39100000000002, 367.52299999999997]]],
             [11, [[54.145, 443.484], [158.39100000000002, 367.52299999999997]]],
             [13, [255, 0, 0]],
             [11, [[106.67199999999998, 533.996], [260.215, 421.668]]],
             [13, [0, 0, 0]],
             [14, 3.36],
             [11,
              [[268.29699999999997, 601.07],
               [307.895, 517.023, 236.781, 480.66, 307.895, 516.215],
               [236.781, 480.66, 307.895, 516.215, 379.008, 551.7730000000001],
               [307.895, 516.215],
               [379.008, 551.7730000000001, 378.199, 551.7730000000001, 378.199, 551.7730000000001],
               [378.199, 551.7730000000001, 378.199, 551.7730000000001, 2.50321870105859e-308, 0.0],
               [378.199, 551.7730000000001]]]],
  b'Size': [595.2755740000001, 841.8897710000001]}]
```

<p align="center">
<a href="https://github.com/scraperwiki/pdf2msgpack/files/347703/test_paths.pdf"><img src="https://cloud.githubusercontent.com/assets/438648/16584279/e9fbb730-42b2-11e6-91ce-9496704f07f1.png" /><br />test_paths.pdf</a>
</p>

